### PR TITLE
Add edges to objects

### DIFF
--- a/arducate/src/components/ARObject.js
+++ b/arducate/src/components/ARObject.js
@@ -3,6 +3,7 @@ import React, { forwardRef, useImperativeHandle, useRef } from "react";
 import { useAtom } from "jotai";
 import { selectedObjectAtom } from "../atoms";
 import { getAsset } from "./Assets"
+import { Edges } from "@react-three/drei";
 
 const ARObject = forwardRef(({ object, isSelected, setTransformControlsRef }, ref) => {
   const [, setSelectedObject] = useAtom(selectedObjectAtom);
@@ -18,18 +19,35 @@ const ARObject = forwardRef(({ object, isSelected, setTransformControlsRef }, re
     setTransformControlsRef(meshRef.current);
   };
 
+  /*
+    This code creates darker edges for the object, based on the object color:
+      1. It takes the object's color and converts it to a darker shade
+      2. The color is first converted from hex to RGB
+      3. Each RGB component is darkened by subtracting 20 (clamped to 0)
+      4. The darkened RGB is then converted back to hex
+  */
+  function getDarkerColor(color) {
+    return color.replace(/^#(..)(..)(..)$/, (_, r, g, b) => {
+      const darken = (c) => Math.max(0, parseInt(c, 16) - 20).toString(16).padStart(2, '0');
+      
+      // Return as hex string "#RRGGBB"
+      return `#${darken(r)}${darken(g)}${darken(b)}`;
+    });
+  }
+
   return (
-    <mesh
-      ref={meshRef}
-      position={object.position || [0, 0, 0]}
-      scale={object.scale || [1, 1, 1]}
-      rotation={object.rotation || [0, 0, 0]}
-      onPointerDown={handlePointerDown}
-    >
-      {/* Add any geometry you want, e.g., a box */}
-      {getAsset(object.type)}
-      <meshStandardMaterial color={object.color || "orange"} />
-    </mesh>
+      <mesh
+        ref={meshRef}
+        position={object.position || [0, 0, 0]}
+        scale={object.scale || [1, 1, 1]}
+        rotation={object.rotation || [0, 0, 0]}
+        onPointerDown={handlePointerDown}
+      >
+        {/* Add any geometry you want, e.g., a box */}
+        {getAsset(object.type)}
+        <meshStandardMaterial color={object.color || "orange"}/>
+        <Edges lineWidth={2} color={getDarkerColor(object.color)} />
+      </mesh>
   );
 });
 


### PR DESCRIPTION
## Pull Request -  Add edges to objects in the canvas

### Description
It was hard to tell the edges for certain objects. This pr adds an edge attribute to the mesh for all objects.
Note: The sphere doesnt have an edge, so nothing to show there

### Related Issues

- Issue: #60 

### Screenshots 
<img width="370" alt="Screenshot 2024-09-05 at 4 47 12 PM" src="https://github.com/user-attachments/assets/fb9a9522-b85f-49d3-b5bd-25a0b7210d08">


### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## SPR stack
**Stack**:
- #64
- #63
- #62 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*