### PR TITLE
Ac/107/Publish-Line-and-Text

### DIFF
--- a/arducate/docs/unit_tests.txt
+++ b/arducate/docs/unit_tests.txt
@@ -13,6 +13,8 @@ Editor Environment: Add 3 shapes of different types
 	Ensure its persistent after clicking and modifying another shape
 	Ensure its persistent in the Preview Environment
 - Try the buttons & sliders – Make sure it performs as expected
+- Text:
+	Ensure text asset is editable and can be transformed as any other object. 
 
 Preview Environment:
 	Can move around in the environment as expected (see all sides and all shapes)

--- a/arducate/src/components/ARObject.js
+++ b/arducate/src/components/ARObject.js
@@ -94,7 +94,7 @@ const ARObject = ({ object, isSelected, setTransformControlsRef }) => {
       {/* Render the correct geometry */}
       {getAsset(object.type, { text: object.text })}
       <meshStandardMaterial color={object.color || "orange"} />
-      {object.type != "text" && object.type != "line" && (
+      {object.type !== "text" && object.type !== "line" && (
         <Edges lineWidth={2} color={getDarkerColor(object.color)} />
       )}
     </mesh>

--- a/arducate/src/components/ARPublish.js
+++ b/arducate/src/components/ARPublish.js
@@ -17,31 +17,7 @@ const convertSceneToAR = (arObjects) => {
       <body style="margin: 0; overflow: hidden;">
         <a-scene embedded arjs renderer="logarithmicDepthBuffer: true;" vr-mode-ui="enabled: false" gesture-detector>
           <a-marker preset="hiro">
-            ${arObjects
-              .map((object) => {
-                return `
-                <a-entity>
-                  <${object.entity} position="${object.position.join(" ")}"
-                    scale="${object.scale.join(
-                      " "
-                    )}" rotation="${object.rotation.join(" ")}"
-                    color="${object.color}"></${object.entity}>
-                  <a-text visible=${object.showLabel} value="${
-                  object.name || `Object ${object.id}`
-                }"
-                    position="${object.position[0]} ${-object.scale[1]} ${
-                  object.position[2]
-                }"
-                    render-order="1"
-                    scale="0.5 0.5 0.5"
-                    align="center"
-                    color="#000000"
-                    opacity="0.8"
-                    side="double"></a-text>
-                </a-entity>
-              `;
-              })
-              .join("")}
+            ${arObjects.map(object => renderObject(object)).join("")}
           </a-marker>
           <a-entity camera></a-entity>
         </a-scene>
@@ -59,41 +35,82 @@ const convertSceneToVR = (arObjects) => {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
+        <script src="https://aframe.io/extras/aframe-extras.min.js"></script>
         <script src="https://unpkg.com/aframe-text-geometry-component@0.5.1/dist/aframe-text-geometry-component.min.js"></script>
       </head>
       <body>
         <a-scene>
-          ${arObjects
-            .map((object) => {
-              return `
-              <a-entity>
-                <${object.entity} position="${object.position.join(" ")}"
-                  scale="${object.scale.join(
-                    " "
-                  )}" rotation="${object.rotation.join(" ")}"
-                  color="${object.color}"></${object.entity}
-                  text=${object.name}>
-                <a-text visible=${object.showLabel} 
-                        value="${object.name || `Object ${object.id}`}"
-                  position="${object.position[0]} ${-object.scale[1]} ${
-                object.position[2]
-              }"
-                  render-order="2"
-                  scale="0.5 0.5 0.5"
-                  align="center"
-                  color="#000000"
-                  opacity="0.8"
-                  side="double"></a-text>
-              </a-entity>
-            `;
-            })
-            .join("")}
+          ${arObjects.map(object => renderObject(object)).join("")}
           <a-sky color="#ECECEC"></a-sky>
           <a-camera position="0 0 4" look-controls="enabled:true"></a-camera>
         </a-scene>
       </body>
       </html>
     `;
+};
+
+// Returns Label for Respective Asset
+const renderTextLabel = (object) => `
+  <a-text 
+    visible="${object.showLabel}" 
+    value="${object.name || `Object ${object.id}`}"
+    position="${object.position[0]} ${-object.scale[1]} ${object.position[2]}"
+    render-order="2"
+    scale="0.5 0.5 0.5"
+    align="center"
+    color="#000000"
+    opacity="0.8"
+    side="double"></a-text>
+`;
+
+// Returns A-frame Entity for Asset
+const renderObject = (object) => {
+  const commonPosition = object.position.join(" ");
+  const commonScale = object.scale.join(" ");
+  const commonRotation = object.rotation.join(" ");
+  const commonTextLabel = renderTextLabel(object);
+
+  switch (object.entity) {
+    case 'a-text':
+      return `
+        <a-entity>
+          <${object.entity} 
+            value="${object.text}"
+            align="center"
+            anchor="center"
+            position="${commonPosition}"
+            scale="${commonScale}"
+            rotation="${commonRotation}"
+            color="#000000"></${object.entity}>
+          ${commonTextLabel}
+        </a-entity>
+      `;
+
+    case 'a-element':
+      return `
+        <a-entity>
+          <a-entity 
+            line="color: black; lineWidth: 2; start: 0 0 0; end: 0 2 0" 
+            position="${commonPosition}"
+            scale="${commonScale}"
+            rotation="${commonRotation}">
+          </a-entity>
+          ${commonTextLabel}
+        </a-entity>
+      `;
+
+    default:
+      return `
+        <a-entity>
+          <${object.entity} 
+            position="${commonPosition}"
+            scale="${commonScale}"
+            rotation="${commonRotation}"
+            color="${object.color}"></${object.entity}>
+          ${commonTextLabel}
+        </a-entity>
+      `;
+  }
 };
 
 export { convertSceneToAR, convertSceneToVR };


### PR DESCRIPTION
## Pull Request - Publish Line and Text

### Description
The line and text asset must be converted into it's html a-frame counterpart for AR/VR publishing. Additional note: text and line doesn't change color for now.

### Related Issues
Link the issues that this pull request addresses, if applicable.
- Issue: #107 

### How Has This Been Tested?

- [ ] Add text and line in canvas as assets. Transform it as you would any other object. Preview in VR.
- [ ] Add text and line in canvas as assets. Transform it as you would any other object. Publish in AR. Please note: When the cameras faces the marker straight on, it acts as the top down view (I.e, think of a cup and a coaster. The object we create is the cup and the marker is the coaster. To see the projection as viewed in canvas/vr, the marker must be laying close to 90 degrees from camera)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/25fc8d97-4e4b-4693-ba83-d7ed3b9d9d7d)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Unit Tests
**Transform Controls:**
- [x] Whatever is selected in the canvas is selected in left, right sidebars 
- [x] Whatever is selected in left sidebar is selected in middle, right sidebars
**Change the color, size, position, rotation of one shape**
- [x] Ensure its persistent after clicking and modifying another shape
- [x] Ensure its persistent in the Preview Environment
- [x] Try the buttons & sliders – Make sure it performs as expected

**Preview Environment:**
- [x] Can move around in the environment as expected (see all sides and all shapes)
- [x] All the graphics & functionality that appears in editor is in preview (i.e. animation, shapes, color, scale, position…)

**Publish Environment:**
- [x] Quick scan that graphics & functionality appears same as in preview

**Animation:** 
- [ ] For 2 assets: Can add two assets and apply an animation to both that executes at the same time 
- [ ] For 1 asset: Can move keyframe around for 1 asset animation, 2 keyframes can be added at a time & works

### Additional Context
Add any other context or screenshots about the pull request here
