### PR TITLE
Ac/90/Add-Rotation-Scale-Animations

### DIFF
--- a/arducate/docs/unit_tests.txt
+++ b/arducate/docs/unit_tests.txt
@@ -1,5 +1,5 @@
 Purpose: This file describes the unit tests that must be conducted prior to merging a PR 
-Date Last Modified: September 24, 2024 
+Date Last Modified: November 3rd, 2024 
 
 ADDING UNIT TESTS - As new features are added, they can be added to this list of tests 
 Please update 'Date Last Modified' after adding a unit test
@@ -15,6 +15,8 @@ Editor Environment: Add 3 shapes of different types
 - Try the buttons & sliders – Make sure it performs as expected
 - Text:
 	Ensure text asset is editable and can be transformed as any other object. 
+- Animation:
+	Can animate rotation, scaling and translation in editor
 
 Preview Environment:
 	Can move around in the environment as expected (see all sides and all shapes)

--- a/arducate/src/components/ARObject.js
+++ b/arducate/src/components/ARObject.js
@@ -75,10 +75,18 @@ const ARObject = ({ object, isSelected, setTransformControlsRef }) => {
     const interpolatedProps = interpolateProperties(object.id);
 
     if (interpolatedProps) {
-      const { position } = interpolatedProps;
+      const { position, rotation, scale } = interpolatedProps;
 
       if (position) {
         meshRef.current.position.set(...position);
+      }
+
+      if (rotation) {
+        meshRef.current.rotation.set(...rotation);
+      }
+      
+      if (scale) {
+        meshRef.current.scale.set(...scale);
       }
     }
   });

--- a/arducate/src/components/ARPublish.js
+++ b/arducate/src/components/ARPublish.js
@@ -49,6 +49,9 @@ const convertSceneToVR = (arObjects) => {
     `;
 };
 
+// Function to convert radians to degrees
+const radiansToDegrees = (radians) => radians * (180 / Math.PI);
+
 // Returns Label for Respective Asset
 const renderTextLabel = (object) => `
   <a-text 
@@ -67,7 +70,7 @@ const renderTextLabel = (object) => `
 const renderObject = (object) => {
   const commonPosition = object.position.join(" ");
   const commonScale = object.scale.join(" ");
-  const commonRotation = object.rotation.join(" ");
+  const commonRotation = object.rotation.map(radiansToDegrees).join(" ");
   const commonTextLabel = renderTextLabel(object);
 
   switch (object.entity) {

--- a/arducate/src/components/Canvas.js
+++ b/arducate/src/components/Canvas.js
@@ -67,8 +67,7 @@ const ARCanvas = () => {
 
     // Create a new Euler from the TransformControls' quaternion
     const euler = new THREE.Euler().setFromQuaternion(transformControlsRef.quaternion);
-    const euler_arr = [euler.x, euler.y, euler.z]
-    const transformedRotation = euler_arr
+    const transformedRotation = [euler.x, euler.y, euler.z]
     
     setARObjects({
       type: 'UPDATE_OBJECT',

--- a/arducate/src/components/Canvas.js
+++ b/arducate/src/components/Canvas.js
@@ -61,16 +61,14 @@ const ARCanvas = () => {
   const [transformMode] = useAtom(transformModeAtom);
   const [transformControlsRef, setTransformControlsRef] = useState(null); // State to store the selected object's mesh ref
 
-  // Function to convert radians to degrees
-  const radiansToDegrees = (radians) => radians * (180 / Math.PI);
-
   // Handle the transformation change and update state
   const handleObjectTransform = useCallback(() => {
     if (!selectedObject || !transformControlsRef) return;
 
     // Create a new Euler from the TransformControls' quaternion
     const euler = new THREE.Euler().setFromQuaternion(transformControlsRef.quaternion);
-    const transformedRotation = euler.toArray().map(radiansToDegrees);
+    const euler_arr = [euler.x, euler.y, euler.z]
+    const transformedRotation = euler_arr
     
     setARObjects({
       type: 'UPDATE_OBJECT',

--- a/arducate/src/controllers/AnimationController.js
+++ b/arducate/src/controllers/AnimationController.js
@@ -137,19 +137,29 @@ const AnimationController = () => {
   };
 
   const interpolateRotation = (start, end, progress) => {
-    if (!start || !end) {
-      console.error('Start or end rotations are undefined');
-      return start || end || [0, 0, 0];
+    if (!start || !end || progress < 0 || progress > 1) {
+        console.error('Invalid input parameters');
+        return [0, 0, 0];
     }
+
+    // Create Euler objects with the correct order
+    const startEuler = new THREE.Euler(...start, 'XYZ');
+    const endEuler = new THREE.Euler(...end, 'XYZ');
+
+    // Convert to quaternions
+    const startQuaternion = new THREE.Quaternion();
+    const endQuaternion = new THREE.Quaternion();
+    startQuaternion.setFromEuler(startEuler);
+    endQuaternion.setFromEuler(endEuler);
+
+    // Perform spherical interpolation (slerp)
+    const interpolatedQuaternion = startQuaternion.clone();
+    interpolatedQuaternion.slerp(endQuaternion, progress);
+
+    // Convert back to Euler angles
+    const interpolatedEuler = new THREE.Euler().setFromQuaternion(interpolatedQuaternion, 'XYZ');
     
-    const startQuaternion = new THREE.Quaternion().setFromEuler(new THREE.Euler(...start));
-    const endQuaternion = new THREE.Quaternion().setFromEuler(new THREE.Euler(...end));
-  
-    const interpolatedQuaternion = new THREE.Quaternion().slerp(startQuaternion, endQuaternion, progress);
-  
-    // Convert back to Euler angles if needed
-    const euler = new THREE.Euler().setFromQuaternion(interpolatedQuaternion);
-    return [euler.x, euler.y, euler.z];
+    return [interpolatedEuler.x, interpolatedEuler.y, interpolatedEuler.z];
   };
 
   const interpolateScale = (start, end, progress) => {


### PR DESCRIPTION
## Pull Request - Include rotation and scale in animation sequencing

### Description
Add rotation and scale properties in animation sequencing to complete animation of transforms. NOTE: PR for publishing line and text must me merged in first.

### Related Issues
Link the issues that this pull request addresses, if applicable.
- Issue: #90 

### How Has This Been Tested?
Describe the tests that you ran to verify your changes. Provide instructions so that others can reproduce. 

- [ ] Added a single asset and animated rotation, scale and translation.

### Screenshots (if applicable)
Add screenshots to demonstrate the changes that were made.

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Unit Tests
**Transform Controls:**
- [ ] Whatever is selected in the canvas is selected in left, right sidebars 
- [ ] Whatever is selected in left sidebar is selected in middle, right sidebars
**Change the color, size, position, rotation of one shape**
- [ ] Ensure its persistent after clicking and modifying another shape
- [ ] Ensure its persistent in the Preview Environment
- [ ] Try the buttons & sliders – Make sure it performs as expected

**Preview Environment:**
- [ ] Can move around in the environment as expected (see all sides and all shapes)
- [ ] All the graphics & functionality that appears in editor is in preview (i.e. animation, shapes, color, scale, position…)

**Publish Environment:**
- [ ] Quick scan that graphics & functionality appears same as in preview

**Animation:** 
- [ ] For 2 assets: Can add two assets and apply an animation to both that executes at the same time 
- [ ] For 1 asset: Can move keyframe around for 1 asset animation, 2 keyframes can be added at a time & works

### Additional Context
Add any other context or screenshots about the pull request here
