### PR TITLE
Seperate name and labels

### DIFF
--- a/arducate/src/components/ARControls.js
+++ b/arducate/src/components/ARControls.js
@@ -55,7 +55,7 @@ const ARControls = () => {
     }
   }, [selectedObject, setARObjects]);
 
-  const handleLabelChange = (e) => {
+  const handleNameChange = (e) => {
     setARObjects({
       type: "UPDATE_OBJECT",
       payload: {
@@ -65,22 +65,21 @@ const ARControls = () => {
     });
   };
 
+  const handleLabelChange = (e) => {
+    setARObjects({
+      type: "UPDATE_OBJECT",
+      payload: {
+        id: selectedObject.id,
+        label: e.target.value,
+      },
+    });
+  };
   const handleLabelVisibilityChange = (checked) => {
     setARObjects({
       type: "UPDATE_OBJECT",
       payload: {
         id: selectedObject.id,
         showLabel: checked,
-      },
-    });
-  };
-
-  const handleTextChange = (e) => {
-    setARObjects({
-      type: "UPDATE_OBJECT",
-      payload: {
-        id: selectedObject.id,
-        text: e.target.value,
       },
     });
   };
@@ -167,10 +166,23 @@ const ARControls = () => {
       <div className="mb-3">
         <div className="flex items-center justify-between gap-2">
           <div className="flex-1">
-            <label className="text-xs font-medium">Label:</label>
+            <label className="text-xs font-medium">Name:</label>
             <input
               type="text"
               value={selectedObject.name}
+              onChange={handleNameChange}
+              className="w-full p-1 border rounded text-sm"
+            />
+          </div>
+        </div>
+      </div>
+      <div className="mb-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex-1">
+            <label className="text-xs font-medium">Label:</label>
+            <input
+              type="text"
+              value={selectedObject.label}
               onChange={handleLabelChange}
               className="w-full p-1 border rounded text-sm"
             />
@@ -186,18 +198,6 @@ const ARControls = () => {
         </div>
       </div>
 
-
-      {selectedObject.type == 'text' && 
-        <div className="mb-4">
-          <label className="block mb-2 text-sm font-medium">Text Input:</label>
-          <input
-            type="text"
-            value={selectedObject.text}
-            onChange={handleTextChange}
-            className="w-full p-2 border rounded"
-          />
-        </div>
-      }
       <div className="mb-4">
         <label className="block mb-2 text-sm font-medium">Color:</label>
         <input

--- a/arducate/src/components/ARObject.js
+++ b/arducate/src/components/ARObject.js
@@ -27,7 +27,7 @@ const ARObject = ({ object, isSelected, setTransformControlsRef }) => {
     if (meshRef.current && object && object.showLabel) {
       const labelDiv = document.createElement("div");
       labelDiv.className = "label";
-      labelDiv.textContent = object.name || `Object ${object.id}`;
+      labelDiv.textContent = object.label || `Object ${object.id}`;
       labelDiv.style.backgroundColor = "rgba(255,255,255,0.8)";
       labelDiv.style.color = "black";
       labelDiv.style.padding = "2px 5px";

--- a/arducate/src/components/AssetHandler.js
+++ b/arducate/src/components/AssetHandler.js
@@ -30,6 +30,7 @@ const AssetHandler = ({ data, setData, cursor, setCursor }) => {
       entity: getArAsset(value),
       keyframes: [], // Initialize keyframes
       name: `${value}-${assetCount}`, // Ensure unique name here
+      label: `${value}-${assetCount}-label`,
       showLabel: true,
       text: "Add Text",
     };

--- a/arducate/src/components/Conversion/utils.js
+++ b/arducate/src/components/Conversion/utils.js
@@ -98,7 +98,7 @@ export const generateAnimations = (keyframes) => {
 export const renderTextLabel = (object) => `
   <a-text 
     visible="${object.showLabel}" 
-    value="${object.name || `Object ${object.id}`}"
+    value="${object.label || `Object ${object.id}`}"
     position="0 ${-object.scale[1]} 0"
     render-order="2"
     scale="0.5 0.5 0.5"
@@ -182,7 +182,7 @@ export const renderObject = (object) => {
           ${animations}>
           <a-text 
             visible="${object.showLabel}" 
-            value="${object.name || `Object ${object.id}`}"
+            value="${object.label || `Object ${object.id}`}"
             position="0 ${-object.scale[1]} 0"
             render-order="1"
             scale="1 1 1"


### PR DESCRIPTION
## Pull Request - Seperate name and labels

### Description
Create a seperate field for name and labels so that objects can have the same label in the canvas/VR/AR but still be distinguisable through different names in the scene graph. 

### Related Issues
Link the issues that this pull request addresses, if applicable.
- Issue: #125 

### How Has This Been Tested?
Describe the tests that you ran to verify your changes. Provide instructions so that others can reproduce. 

- [ ] Test A
- [ ] Test B

### Screenshots (if applicable)
Add screenshots to demonstrate the changes that were made.

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Unit Tests
**Transform Controls:**
- [ ] Whatever is selected in the canvas is selected in left, right sidebars 
- [ ] Whatever is selected in left sidebar is selected in middle, right sidebars
**Change the color, size, position, rotation of one shape**
- [ ] Ensure its persistent after clicking and modifying another shape
- [ ] Ensure its persistent in the Preview Environment
- [ ] Try the buttons & sliders – Make sure it performs as expected

**Preview Environment:**
- [ ] Can move around in the environment as expected (see all sides and all shapes)
- [ ] All the graphics & functionality that appears in editor is in preview (i.e. animation, shapes, color, scale, position…)

**Publish Environment:**
- [ ] Quick scan that graphics & functionality appears same as in preview

**Animation:** 
- [ ] For 2 assets: Can add two assets and apply an animation to both that executes at the same time 
- [ ] For 1 asset: Can move keyframe around for 1 asset animation, 2 keyframes can be added at a time & works

### Additional Context
Add any other context or screenshots about the pull request here
