### PR TITLE
Ac/128/fix-color-mismatch-in-canvas

### DIFF
--- a/arducate/src/components/ARObject.js
+++ b/arducate/src/components/ARObject.js
@@ -106,7 +106,7 @@ const ARObject = ({ object, isSelected, setTransformControlsRef }) => {
     >
       {/* Render the correct geometry */}
       {getAsset(object.type, { text: object.text })}
-      <meshStandardMaterial color={object.color || "orange"} />
+      <meshBasicMaterial color={object.color || "orange"} toneMapped={false}/>
       {object.type !== "text" && object.type !== "line" && (
         <Edges lineWidth={2} color={getDarkerColor(object.color)} />
       )}


### PR DESCRIPTION
## Pull Request - Fix the mismatch of color in canvas.

### Description
Currently, color of assets were not accurately displayed with the hex code, causing inconsistencies with the canvas and the eyedropper, ar/vr viewer. Changed the asset mesh to be basic instead of standard and turned tone mapping off.

### Related Issues
Link the issues that this pull request addresses, if applicable.
- Issue: #128 

### How Has This Been Tested?
When using the eyedropper tool on th current asset's color, the color should now remain the same. Additionally, all color that is selected should match the eyedropper, the asset (in the canvas, when published or previewed in ar/vr).

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/c65a3ec5-6da7-47ea-b7dd-a62bcaa80dc1)

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Unit Tests
**Transform Controls:**
- [ ] Whatever is selected in the canvas is selected in left, right sidebars 
- [ ] Whatever is selected in left sidebar is selected in middle, right sidebars
**Change the color, size, position, rotation of one shape**
- [ ] Ensure its persistent after clicking and modifying another shape
- [ ] Ensure its persistent in the Preview Environment
- [ ] Try the buttons & sliders – Make sure it performs as expected

**Preview Environment:**
- [ ] Can move around in the environment as expected (see all sides and all shapes)
- [ ] All the graphics & functionality that appears in editor is in preview (i.e. animation, shapes, color, scale, position…)

**Publish Environment:**
- [ ] Quick scan that graphics & functionality appears same as in preview

**Animation:** 
- [ ] For 2 assets: Can add two assets and apply an animation to both that executes at the same time 
- [ ] For 1 asset: Can move keyframe around for 1 asset animation, 2 keyframes can be added at a time & works

### Additional Context
Add any other context or screenshots about the pull request here
