### PR TITLE
Hs/ux updates

### DIFF
--- a/arducate/src/App.js
+++ b/arducate/src/App.js
@@ -8,13 +8,14 @@ import Sidebar from "./components/Sidebar";
 import SequenceEditor from "./components/SequenceEditor/SequenceEditor";
 import ARContentViewer from "./components/ARContentViewer"; // Create this component in Step 3
 import AssetControllers from "./components/AssetControllers";
-import { copyBufferAtom, selectedObjectAtom, arObjectsAtom } from "./atoms";
+import { copyBufferAtom, selectedObjectAtom, arObjectsAtom, historyAtom } from "./atoms";
 import { useAtom } from "jotai";
 
 const App = () => {
   const [arObjects, setARObjects] = useAtom(arObjectsAtom);
   const [selectedObject] = useAtom(selectedObjectAtom);
   const [copyBuffer, setCopyBuffer] = useAtom(copyBufferAtom);
+  const [historyLog, setHistory] = useAtom(historyAtom);
 
   // lets listen for any control c or control v events
   useEffect(() => {
@@ -45,15 +46,40 @@ const App = () => {
           };
           setARObjects({ type: "ADD_OBJECT", payload: newObject });
         }
-      }
-    };
+      } else if((e.ctrlKey || e.metaKey) && e.key === "z") {
+        if (historyLog.length === 0) return;
+        // check the last history object and undo it
+        const history = historyLog[historyLog.length - 1];
+        
+        if (!history) return;
 
+        const { action, from, to, timestamp } = history;
+
+        switch (action) {
+          case 'ADD_OBJECT':
+            setARObjects({ type: 'REMOVE_OBJECT', payload: to.id });
+
+            break;
+          case 'REMOVE_OBJECT':
+            setARObjects({ type: 'ADD_OBJECT', payload: from });
+            break;
+          case 'UPDATE_OBJECT':
+            setARObjects({ type: 'UPDATE_OBJECT', payload: from });
+            break;
+          default:
+            console.error('Unknown action type:', action);
+        }
+        // slice twice since each revert will add a new history object
+        setHistory(historyLog.slice(0, -1));
+        setHistory(historyLog.slice(0, -1));
+      }
+    }
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [selectedObject, arObjects, copyBuffer, setCopyBuffer, setARObjects]);
+  }, [selectedObject, arObjects, copyBuffer, setCopyBuffer, setARObjects, historyLog, setHistory]);
 
   return (
     <Router>

--- a/arducate/src/App.js
+++ b/arducate/src/App.js
@@ -1,52 +1,92 @@
 // src/App.js
 // src/App.js
-import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import ARCanvas from './components/Canvas';
-import Toolbar from './components/Toolbar';
-import Sidebar from './components/Sidebar';
-import SequenceEditor from './components/SequenceEditor/SequenceEditor';
-import ARContentViewer from './components/ARContentViewer'; // Create this component in Step 3
-import AssetControllers from 'components/AssetControllers';
+import React, { useEffect } from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import ARCanvas from "./components/Canvas";
+import Toolbar from "./components/Toolbar";
+import Sidebar from "./components/Sidebar";
+import SequenceEditor from "./components/SequenceEditor/SequenceEditor";
+import ARContentViewer from "./components/ARContentViewer"; // Create this component in Step 3
+import AssetControllers from "./components/AssetControllers";
+import { copyBufferAtom, selectedObjectAtom, arObjectsAtom } from "./atoms";
+import { useAtom } from "jotai";
 
 const App = () => {
-  return (
+  const [arObjects, setARObjects] = useAtom(arObjectsAtom);
+  const [selectedObject] = useAtom(selectedObjectAtom);
+  const [copyBuffer, setCopyBuffer] = useAtom(copyBufferAtom);
 
+  // lets listen for any control c or control v events
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "c") {
+        console.log(selectedObject, selectedObjectAtom, arObjectsAtom);
+
+        const objectToCopy = selectedObject
+          ? arObjects.find((obj) => obj.id === selectedObject.id)
+          : null;
+        // if an object is selected, copy it into the copy buffer
+        if (objectToCopy && objectToCopy.id) {
+          setCopyBuffer(objectToCopy);
+        }
+      } else if ((e.ctrlKey || e.metaKey) && e.key === "v") {
+        // if there is an object in the copy buffer, paste it into the scene
+        if (copyBuffer) {
+          const newObject = {
+            ...copyBuffer,
+            id: Date.now(),
+            name: `${copyBuffer.name} Copy`,
+            label: `${copyBuffer.label} Copy`,
+            position: [
+              copyBuffer.position[0] + 0.1,
+              copyBuffer.position[1] + 0.1,
+              copyBuffer.position[2] + 0.1,
+            ],
+          };
+          setARObjects({ type: "ADD_OBJECT", payload: newObject });
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [selectedObject, arObjects, copyBuffer, setCopyBuffer, setARObjects]);
+
+  return (
     <Router>
-    <Routes>
-      {/* Main AR Editor Interface */}
-      <Route
-        path="/"
-        element={
-          <div className="flex flex-col items-center h-screen">
-          <Toolbar className="flex-shrink-0" />
-          <div className="flex flex-1 w-full relative">
-            {/* Sidebar should stay fixed */}
-    
-            {/* ARCanvas should fill remaining space */}
-            <div className="flex flex-1 h-full">
+      <Routes>
+        {/* Main AR Editor Interface */}
+        <Route
+          path="/"
+          element={
+            <div className="flex flex-col items-center h-screen">
+              <Toolbar className="flex-shrink-0" />
+              <div className="flex flex-1 w-full relative">
+                {/* Sidebar should stay fixed */}
+
+                {/* ARCanvas should fill remaining space */}
+                <div className="flex flex-1 h-full">
                   <ARCanvas className="w-full h-full" />
                   {/* Sidebar overlays on top with absolute positioning */}
                   <Sidebar className="absolute top-0 left-0" />
                 </div>
-    
-            {/* AssetControllers remains on the side */}
-            <AssetControllers className="min-w-[20vw] flex-none" />
-          </div>
-          <SequenceEditor />
-        </div>
-        }
-      />
-      
-      {/* Dynamic AR Content Route */}
-      <Route path="/ar-content/:uniqueId" element={<ARContentViewer />} />
-    </Routes>
-  </Router>
 
+                {/* AssetControllers remains on the side */}
+                <AssetControllers className="min-w-[20vw] flex-none" />
+              </div>
+              <SequenceEditor />
+            </div>
+          }
+        />
 
+        {/* Dynamic AR Content Route */}
+        <Route path="/ar-content/:uniqueId" element={<ARContentViewer />} />
+      </Routes>
+    </Router>
   );
 };
-
-
 
 export default App;

--- a/arducate/src/App.js
+++ b/arducate/src/App.js
@@ -22,15 +22,15 @@ const App = () => {
           <Toolbar className="flex-shrink-0" />
           <div className="flex flex-1 w-full">
             {/* Sidebar should stay fixed */}
-            <Sidebar className="flex-none w-[15vw] min-w-[15vw]" />
     
             {/* ARCanvas should fill remaining space */}
             <div className="flex-1 flex h-full">
+              <Sidebar className="flex-none w-[15vw] min-w-[15vw]" />
               <ARCanvas className="w-full h-full" />
             </div>
     
             {/* AssetControllers remains on the side */}
-            <AssetControllers className="flex-none" />
+            <AssetControllers className="min-w-[20vw] flex-none" />
           </div>
           <SequenceEditor />
         </div>

--- a/arducate/src/App.js
+++ b/arducate/src/App.js
@@ -20,14 +20,15 @@ const App = () => {
         element={
           <div className="flex flex-col items-center h-screen">
           <Toolbar className="flex-shrink-0" />
-          <div className="flex flex-1 w-full">
+          <div className="flex flex-1 w-full relative">
             {/* Sidebar should stay fixed */}
     
             {/* ARCanvas should fill remaining space */}
-            <div className="flex-1 flex h-full">
-              <Sidebar className="flex-none w-[15vw] min-w-[15vw]" />
-              <ARCanvas className="w-full h-full" />
-            </div>
+            <div className="flex flex-1 h-full">
+                  <ARCanvas className="w-full h-full" />
+                  {/* Sidebar overlays on top with absolute positioning */}
+                  <Sidebar className="absolute top-0 left-0" />
+                </div>
     
             {/* AssetControllers remains on the side */}
             <AssetControllers className="min-w-[20vw] flex-none" />

--- a/arducate/src/atoms/index.js
+++ b/arducate/src/atoms/index.js
@@ -3,6 +3,19 @@ import { atom } from "jotai";
 
 // This is where we can add all the global atoms that we want to use
 
+
+/*
+store the version history, to be used for undo/redo
+structure of history object:
+{
+  action: 'ADD_OBJECT' | 'REMOVE_OBJECT' | 'UPDATE_OBJECT',
+  from: object,
+  to: object,
+  timestamp: Date.now(),
+}
+*/
+export const historyAtom = atom([]);
+
 // Helper function to recursively remove an object from treeData
 const removeFromTreeData = (node, idToRemove) => {
   if (node.children) {
@@ -30,13 +43,31 @@ export const arObjectsAtom = atom(
             ...treeData,
             children: [...treeData.children, newObject],
           };
+        });
+
+        const historyLog = {
+          action: 'ADD_OBJECT',
+          from: null,
+          to: action.payload,
+          timestamp: Date.now(),
         }
-        );
+
+        set(historyAtom, [...get(historyAtom), historyLog]);
         break;
       case 'REMOVE_OBJECT':
+        const objectToRemove = get(arObjectsAtom).find(obj => obj.id === action.payload);
         set(arObjectsAtom, get(arObjectsAtom).filter(obj => obj.id !== action.payload)); //sets arObjects to one without that ID in it
         set(selectedObjectAtom, null);
         set(treeDataAtom, treeData => removeFromTreeData({...treeData}, action.payload));
+
+        const historyLogRemove = {
+          action: 'REMOVE_OBJECT',
+          from: objectToRemove, // Store the full object
+          to: null,
+          timestamp: Date.now(),
+        };
+        set(historyAtom, [...get(historyAtom), historyLogRemove]);
+        
 
         break;
         case 'UPDATE_OBJECT':
@@ -50,6 +81,7 @@ export const arObjectsAtom = atom(
             }
             return obj;
           });
+          const prevState = updatedObjects.find(obj => obj.id === action.payload.id);
           set(arObjectsAtom, updatedObjects);
 
           // Update selectedObjectAtom if it's the object being updated
@@ -59,6 +91,13 @@ export const arObjectsAtom = atom(
             // console.log('Atom UPDATE_OBJECT - Updating selectedObject:', updatedSelected);
             set(selectedObjectAtom, updatedSelected);
           }
+          const historyLogUpdate = {
+            action: 'UPDATE_OBJECT',
+            from: prevState,
+            to: updatedObjects,
+            timestamp: Date.now(),
+          }
+          set(historyAtom, [...get(historyAtom), historyLogUpdate]);
           break;
       default:
         console.error('Unknown action type:', action.type);

--- a/arducate/src/atoms/index.js
+++ b/arducate/src/atoms/index.js
@@ -20,6 +20,18 @@ export const arObjectsAtom = atom(
     switch (action.type) {
       case 'ADD_OBJECT':
         set(arObjectsAtom, [...get(arObjectsAtom), action.payload]); //payload: newObject adds to end of arObjects
+        // add it to the treeData
+        set(treeDataAtom, treeData => {
+          const newObject = {
+            id: action.payload.id,
+            name: action.payload.name,
+          };
+          return {
+            ...treeData,
+            children: [...treeData.children, newObject],
+          };
+        }
+        );
         break;
       case 'REMOVE_OBJECT':
         set(arObjectsAtom, get(arObjectsAtom).filter(obj => obj.id !== action.payload)); //sets arObjects to one without that ID in it
@@ -28,12 +40,12 @@ export const arObjectsAtom = atom(
 
         break;
         case 'UPDATE_OBJECT':
-          console.log('Atom UPDATE_OBJECT - Received payload:', action.payload);
+          // console.log('Atom UPDATE_OBJECT - Received payload:', action.payload);
           const updatedObjects = get(arObjectsAtom).map(obj => {
             if (obj.id === action.payload.id) {
               const updatedObj = { ...obj, ...action.payload };
-              console.log('Atom UPDATE_OBJECT - Before update:', obj);
-              console.log('Atom UPDATE_OBJECT - After update:', updatedObj);
+              // console.log('Atom UPDATE_OBJECT - Before update:', obj);
+              // console.log('Atom UPDATE_OBJECT - After update:', updatedObj);
               return updatedObj;
             }
             return obj;
@@ -44,7 +56,7 @@ export const arObjectsAtom = atom(
           const currentSelected = get(selectedObjectAtom);
           if (currentSelected && currentSelected.id === action.payload.id) {
             const updatedSelected = updatedObjects.find(obj => obj.id === action.payload.id);
-            console.log('Atom UPDATE_OBJECT - Updating selectedObject:', updatedSelected);
+            // console.log('Atom UPDATE_OBJECT - Updating selectedObject:', updatedSelected);
             set(selectedObjectAtom, updatedSelected);
           }
           break;
@@ -53,6 +65,7 @@ export const arObjectsAtom = atom(
     }
   }
 );
+
 // Atom to manage the data in treeboard
 export const treeDataAtom = atom({
   name: "root",
@@ -78,3 +91,5 @@ export const timelineDurationAtom = atom(20);
 
 export const selectedKeyframeAtom = atom({ keyframeId: null, objectId: null });
 export const interpolationsAtom = atom({});
+
+export const copyBufferAtom = atom(null);

--- a/arducate/src/components/ARControls.js
+++ b/arducate/src/components/ARControls.js
@@ -23,7 +23,7 @@ const ARControls = () => {
   if (!selectedObject) {
     return (
       <div className="w-[15vw] h-full flex flex-col items-center justify-center bg-secondary text-gray-700 rounded-lg p-4">
-        <div className="text-lg font-semibold">No Object Selected</div>
+        <div className="text-lg font-semibold text-center">No Object Selected</div>
         <p className="text-sm text-gray-500 mt-1 text-center">
           Please select an object to view its details.
         </p>

--- a/arducate/src/components/ARObject.js
+++ b/arducate/src/components/ARObject.js
@@ -36,7 +36,7 @@ const ARObject = ({ object, isSelected, setTransformControlsRef }) => {
       labelDiv.style.fontSize = "10px";
       labelDiv.style.pointerEvents = "none";
       const label = new CSS2DObject(labelDiv);
-      label.position.set(0, object.position[1]/object.scale[1], 0);
+      label.position.set(-1, object.position[1] - 0.3, 0);
       meshRef.current.add(label);
       labelRef.current = label;
 

--- a/arducate/src/components/ARObject.js
+++ b/arducate/src/components/ARObject.js
@@ -105,10 +105,12 @@ const ARObject = ({ object, isSelected, setTransformControlsRef }) => {
       scale={object.scale || [1, 1, 1]}
       rotation={object.rotation.slice(0, 3).map(deg => THREE.MathUtils.degToRad(deg))}
       onPointerDown={handlePointerDown}
+      castShadow
+      receiveShadow
     >
       {/* Render the correct geometry */}
       {getAsset(object.type, { text: object.text, color: object.color })}
-      <meshBasicMaterial color={object.color || "orange"} toneMapped={false}/>
+      <meshMatcapMaterial color={object.color || "orange"} toneMapped={false} />
       {object.type !== "text" && object.type !== "line" && (
         <Edges lineWidth={2} color={getDarkerColor(object.color)} />
       )}

--- a/arducate/src/components/AssetControllers.js
+++ b/arducate/src/components/AssetControllers.js
@@ -29,7 +29,7 @@ const AssetControllers = () => {
   };
 
   return (
-    <div className="w-[18vw] h-[63vh] bg-secondary rounded shadow-lg overflow-y-auto">
+    <div className="w-[25vw] h-[63vh] bg-secondary rounded shadow-lg overflow-y-auto">
       <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
         <TabsList className="grid grid-cols-2 w-full sticky top-0 bg-secondary z-10">
           <TabsTrigger

--- a/arducate/src/components/AssetControllers.js
+++ b/arducate/src/components/AssetControllers.js
@@ -29,7 +29,7 @@ const AssetControllers = () => {
   };
 
   return (
-    <div className="w-[25vw] h-[63vh] bg-secondary rounded shadow-lg overflow-y-auto">
+    <div className="w-[25vw] h-[63vh] bg-secondary rounded overflow-y-auto">
       <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
         <TabsList className="grid grid-cols-2 w-full sticky top-0 bg-secondary z-10">
           <TabsTrigger

--- a/arducate/src/components/Canvas.js
+++ b/arducate/src/components/Canvas.js
@@ -118,7 +118,7 @@ const ARCanvas = () => {
   }, [transformControlsRef, handleObjectTransform]);
 
   return (
-    <div className="w-[68vw] border border-gray-300">
+    <div className="w-[82vw] border border-gray-300">
       <Canvas camera={{ position: [0, 2, 5], fov: 60 }}>
         <CSS2DRendererSetup />
 

--- a/arducate/src/components/Canvas.js
+++ b/arducate/src/components/Canvas.js
@@ -7,7 +7,7 @@ import { arObjectsAtom, selectedObjectAtom, transformModeAtom } from "../atoms";
 import ARObject from "./ARObject";
 import { CSS2DRenderer } from "three/examples/jsm/renderers/CSS2DRenderer";
 import { useThree, useFrame } from "@react-three/fiber";
-import * as THREE from 'three';
+import * as THREE from "three";
 
 // This function sets up and manages the CSS2DRenderer for rendering 2D labels in a 3D scene
 function CSS2DRendererSetup() {
@@ -20,11 +20,11 @@ function CSS2DRendererSetup() {
     // Set the renderer size to match the window dimensions
     labelRendererRef.current.setSize(window.innerWidth, window.innerHeight);
     // Configure the renderer's DOM element styles
-    labelRendererRef.current.domElement.style.position = 'absolute';
-    labelRendererRef.current.domElement.style.top = '0px';
-    labelRendererRef.current.domElement.style.left = '0px'; // Ensure it's aligned properly
-    labelRendererRef.current.domElement.style.pointerEvents = 'none';
-    labelRendererRef.current.domElement.style.zIndex = '1'; // Ensure it's on top
+    labelRendererRef.current.domElement.style.position = "absolute";
+    labelRendererRef.current.domElement.style.top = "0px";
+    labelRendererRef.current.domElement.style.left = "0px"; // Ensure it's aligned properly
+    labelRendererRef.current.domElement.style.pointerEvents = "none";
+    labelRendererRef.current.domElement.style.zIndex = "1"; // Ensure it's on top
 
     document.body.appendChild(labelRendererRef.current.domElement);
 
@@ -32,14 +32,14 @@ function CSS2DRendererSetup() {
     const onResize = () => {
       labelRendererRef.current.setSize(window.innerWidth, window.innerHeight);
     };
-    window.addEventListener('resize', onResize);
+    window.addEventListener("resize", onResize);
 
     // Cleanup function to remove the renderer and event listener when component unmounts
     return () => {
       if (labelRendererRef.current && labelRendererRef.current.domElement) {
         labelRendererRef.current.domElement.remove();
       }
-      window.removeEventListener('resize', onResize);
+      window.removeEventListener("resize", onResize);
     };
   }, []);
 
@@ -65,38 +65,39 @@ const ARCanvas = () => {
   const [transformControlsRef, setTransformControlsRef] = useState(null); // State to store the selected object's mesh ref
 
   // Handle the transformation change and update state
-const handleObjectTransform = useCallback(() => {
-  if (!selectedObject || !transformControlsRef) return;
+  const handleObjectTransform = useCallback(() => {
+    if (!selectedObject || !transformControlsRef) return;
 
-  // Create a new Euler from the TransformControls' quaternion
-  const euler = new THREE.Euler().setFromQuaternion(transformControlsRef.quaternion);
-  const transformedRotation = [
-    radiansToDegrees(euler.x),
-    radiansToDegrees(euler.y), 
-    radiansToDegrees(euler.z)
-  ]; // Only keep 3 values, no NaN
+    // Create a new Euler from the TransformControls' quaternion
+    const euler = new THREE.Euler().setFromQuaternion(
+      transformControlsRef.quaternion
+    );
+    const transformedRotation = [
+      radiansToDegrees(euler.x),
+      radiansToDegrees(euler.y),
+      radiansToDegrees(euler.z),
+    ]; // Only keep 3 values, no NaN
 
-  setARObjects({
-    type: 'UPDATE_OBJECT',
-    payload: {
-      id: selectedObject.id,
-      position: transformControlsRef.position.toArray(),
-      rotation: transformedRotation,
-      scale: transformControlsRef.scale.toArray(),
-    }
-  });
+    setARObjects({
+      type: "UPDATE_OBJECT",
+      payload: {
+        id: selectedObject.id,
+        position: transformControlsRef.position.toArray(),
+        rotation: transformedRotation,
+        scale: transformControlsRef.scale.toArray(),
+      },
+    });
   }, [transformControlsRef, setARObjects]);
 
-  
   // Grid configuration
   const gridConfig = {
     args: [10.5, 10.5],
     cellSize: 0.6,
     cellThickness: 1,
-    cellColor: '#6f6f6f',
+    cellColor: "#6f6f6f",
     sectionSize: 3.3,
     sectionThickness: 1.5,
-    sectionColor: '#9d4b4b',
+    sectionColor: "#9d4b4b",
     fadeDistance: 25,
     fadeStrength: 1,
     followCamera: false,
@@ -106,21 +107,28 @@ const handleObjectTransform = useCallback(() => {
   // Attach event listener for TransformControls changes
   useEffect(() => {
     if (transformControlsRef) {
-      transformControlsRef.addEventListener('change', handleObjectTransform);
+      transformControlsRef.addEventListener("change", handleObjectTransform);
       return () => {
-        transformControlsRef.removeEventListener('change', handleObjectTransform);
+        transformControlsRef.removeEventListener(
+          "change",
+          handleObjectTransform
+        );
       };
     }
   }, [transformControlsRef, handleObjectTransform]);
 
   return (
-    <div className="w-[70vw] border border-gray-300">
-      <Canvas camera={{ position: [0, 2, 5], fov: 60  }}>
+    <div className="w-[68vw] border border-gray-300">
+      <Canvas camera={{ position: [0, 2, 5], fov: 60 }}>
         <CSS2DRendererSetup />
 
         {/* Lights */}
         <ambientLight intensity={0.5} />
-        <directionalLight position={[5, 5, 5]} />
+        <directionalLight
+          position={[5, 10, 5]} // Position the light]
+          intensity={1}
+          castShadow
+        />
 
         {/* Grid */}
         <Grid {...gridConfig} />
@@ -136,13 +144,15 @@ const handleObjectTransform = useCallback(() => {
         ))}
 
         {/* TransformControls for selected object */}
-        {selectedObject && transformControlsRef && selectedObject.visible !== false && (
-          <TransformControls
-            object={transformControlsRef} // Attach transform controls to the selected object's mesh
-            mode={transformMode}
-            onChange={handleObjectTransform}
-          />
-        )}
+        {selectedObject &&
+          transformControlsRef &&
+          selectedObject.visible !== false && (
+            <TransformControls
+              object={transformControlsRef} // Attach transform controls to the selected object's mesh
+              mode={transformMode}
+              onChange={handleObjectTransform}
+            />
+          )}
 
         <OrbitControls makeDefault />
       </Canvas>

--- a/arducate/src/components/SceneGraph.js
+++ b/arducate/src/components/SceneGraph.js
@@ -189,30 +189,28 @@ const SceneGraph = ({ data, setData }) => {
         <div className="p-2">Layers</div>
       </div>
       <div className="overflow-x-auto overflow-y-auto max-h-[calc(100%-3rem)] p-2">
-        <div className="min-w-max">
-          {data.children && data.children.length > 0 ? (
-            data.children.map((childNode) => (
-              <TreeNode
-                key={childNode.id}
-                node={childNode}
-                level={0}
-                onToggle={handleToggle}
-                onAddFolder={handleAddFolder}
-                onRename={handleRename}
-                selectedId={selectedObject?.id}
-                onSelect={handleSelect}
-              />
-            ))
-          ) : (
-            <div className="flex items-center flex-col justify-center h-full text-gray-500">
-              <div className="text-lg font-semibold">No Assets Added</div>
-              <p className="text-sm text-gray-500 mt-1 text-center">
-                Your 3D assets will show here
-              </p>
-            </div>
-          )}
-        </div>
-    </div>
+        {data.children && data.children.length > 0 ? (
+          data.children.map((childNode) => (
+            <TreeNode
+              key={childNode.id}
+              node={childNode}
+              level={0}
+              onToggle={handleToggle}
+              onAddFolder={handleAddFolder}
+              onRename={handleRename}
+              selectedId={selectedObject?.id}
+              onSelect={handleSelect}
+            />
+          ))
+        ) : (
+          <div className="flex items-center flex-col justify-center h-full text-gray-500">
+            <div className="text-lg font-semibold">No Assets Added</div>
+            <p className="text-sm text-gray-500 mt-1 text-center">
+              Your 3D assets will show here
+            </p>
+          </div>
+        )}
+      </div>
     </Card>
   );
 };

--- a/arducate/src/components/SceneGraph.js
+++ b/arducate/src/components/SceneGraph.js
@@ -188,7 +188,7 @@ const SceneGraph = ({ data, setData }) => {
       <div className="font-sm font-bold mb-2 border-b border-gray-200">
         <div className="p-2">Layers</div>
       </div>
-      <div className="overflow-x-auto overflow-y-auto max-h-[calc(100%-3rem)] p-2">
+      <div className="overflow-x-auto overflow-y-auto max-h-[21rem]">
         {data.children && data.children.length > 0 ? (
           data.children.map((childNode) => (
             <TreeNode

--- a/arducate/src/components/Sidebar.js
+++ b/arducate/src/components/Sidebar.js
@@ -32,7 +32,7 @@ const Sidebar = () => {
   };
 
   return (
-    <div className="w-[15vw] items-center p-2 bg-secondary flex flex-col space-y-2 overflow-y-auto">
+    <div className="absolute top-0 left-0 z-10 w-[15vw] items-center p-2 bg-transparent flex flex-col space-y-2 overflow-y-auto">
       {/* Add Action */}
       <div className="navbar-button-container flex flex-row space-x-2">
         <Button

--- a/arducate/src/components/Toolbar.js
+++ b/arducate/src/components/Toolbar.js
@@ -4,6 +4,7 @@ import { arObjectsAtom, transformModeAtom } from "../atoms";
 import { convertSceneToAR } from "./Conversion/ARPublish";
 import { convertSceneToVR } from "./Conversion/VRPublish";
 import { Button } from "../@/components/ui/button";
+import { Share2 } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -145,11 +146,11 @@ const Toolbar = () => {
       </div>
 
       {/* Center Aligned */}
-      <div className="flex-grow text-center">
+      {/* <div className="flex-grow text-center">
         <h2 className="scroll-m-20 text-1xl font-semibold text-white">
           ARducate
         </h2>
-      </div>
+      </div> */}
 
       {/* Right Aligned */}
       <div className="navbar-button-container">
@@ -175,7 +176,10 @@ const Toolbar = () => {
           className="navbar-button"
           onClick={handleShare}
         >
-          Share
+          <Share2 
+            className="w-5 h-auto"
+            title="Share"
+          />
         </Button>
 
         {/* Popup Notification */}


### PR DESCRIPTION
## Pull Request - Cut Copy Paste and some

### Description
This PR does a couple of things
1. Makes the sidebar take up less space
<img width="309" alt="Screenshot 2025-03-24 at 4 46 05 PM" src="https://github.com/user-attachments/assets/06149583-268a-4de1-8dea-bf5ac3677463" />

2. adds a cut, copy, past option
you should be able to ctrl/cmd + c to copy an object and all its properties (including keyframes) and use cmd/ctrl + v to paste it on the canvas. Additionally, every action is recorded in a `historyAtom` that stores a log to undo from, you can use cmd/ctrl + z to undo stuff (we can also add redo but thats more performance intensive).

** note: ** for undo, sometimes the changes take place over multiple steps, so you might have to keep pressing cmd/ctrl + z to roll back properly (we cna add heuristics for this but again, too much work for a small improvement)
 
### How Has This Been Tested?

- [ ] Create objects in different orientations and cut copy them
- [ ] Try moving objects and cmd + z them 

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Unit Tests
**Transform Controls:**
- [ ] Whatever is selected in the canvas is selected in left, right sidebars 
- [ ] Whatever is selected in left sidebar is selected in middle, right sidebars
**Change the color, size, position, rotation of one shape**
- [ ] Ensure its persistent after clicking and modifying another shape
- [ ] Ensure its persistent in the Preview Environment
- [ ] Try the buttons & sliders – Make sure it performs as expected

**Preview Environment:**
- [ ] Can move around in the environment as expected (see all sides and all shapes)
- [ ] All the graphics & functionality that appears in editor is in preview (i.e. animation, shapes, color, scale, position…)

**Publish Environment:**
- [ ] Quick scan that graphics & functionality appears same as in preview

**Animation:** 
- [ ] For 2 assets: Can add two assets and apply an animation to both that executes at the same time 
- [ ] For 1 asset: Can move keyframe around for 1 asset animation, 2 keyframes can be added at a time & works

### Additional Context
Add any other context or screenshots about the pull request here
