### PR TITLE
Shortcuts for keyframe and transform AND rotate fix

### DIFF
--- a/arducate/src/App.js
+++ b/arducate/src/App.js
@@ -67,7 +67,6 @@ const App = () => {
         switch (action) {
           case "ADD_OBJECT":
             setARObjects({ type: "REMOVE_OBJECT", payload: to.id });
-
             break;
           case "REMOVE_OBJECT":
             setARObjects({ type: "ADD_OBJECT", payload: from });

--- a/arducate/src/App.js
+++ b/arducate/src/App.js
@@ -8,14 +8,23 @@ import Sidebar from "./components/Sidebar";
 import SequenceEditor from "./components/SequenceEditor/SequenceEditor";
 import ARContentViewer from "./components/ARContentViewer"; // Create this component in Step 3
 import AssetControllers from "./components/AssetControllers";
-import { copyBufferAtom, selectedObjectAtom, arObjectsAtom, historyAtom } from "./atoms";
+import {
+  copyBufferAtom,
+  selectedObjectAtom,
+  arObjectsAtom,
+  historyAtom,
+  transformModeAtom,
+} from "./atoms";
+import useKeyframe from "./hooks/useKeyframe";
 import { useAtom } from "jotai";
 
 const App = () => {
   const [arObjects, setARObjects] = useAtom(arObjectsAtom);
-  const [selectedObject] = useAtom(selectedObjectAtom);
+  const [selectedObject, setSelectedObject] = useAtom(selectedObjectAtom);
   const [copyBuffer, setCopyBuffer] = useAtom(copyBufferAtom);
   const [historyLog, setHistory] = useAtom(historyAtom);
+  const { addKeyframe } = useKeyframe();
+  const [, setTransformMode] = useAtom(transformModeAtom);
 
   // lets listen for any control c or control v events
   useEffect(() => {
@@ -46,40 +55,65 @@ const App = () => {
           };
           setARObjects({ type: "ADD_OBJECT", payload: newObject });
         }
-      } else if((e.ctrlKey || e.metaKey) && e.key === "z") {
+      } else if ((e.ctrlKey || e.metaKey) && e.key === "z") {
         if (historyLog.length === 0) return;
         // check the last history object and undo it
         const history = historyLog[historyLog.length - 1];
-        
+
         if (!history) return;
 
         const { action, from, to, timestamp } = history;
 
         switch (action) {
-          case 'ADD_OBJECT':
-            setARObjects({ type: 'REMOVE_OBJECT', payload: to.id });
+          case "ADD_OBJECT":
+            setARObjects({ type: "REMOVE_OBJECT", payload: to.id });
 
             break;
-          case 'REMOVE_OBJECT':
-            setARObjects({ type: 'ADD_OBJECT', payload: from });
+          case "REMOVE_OBJECT":
+            setARObjects({ type: "ADD_OBJECT", payload: from });
             break;
-          case 'UPDATE_OBJECT':
-            setARObjects({ type: 'UPDATE_OBJECT', payload: from });
+          case "UPDATE_OBJECT":
+            setARObjects({ type: "UPDATE_OBJECT", payload: from });
             break;
           default:
-            console.error('Unknown action type:', action);
+            console.error("Unknown action type:", action);
         }
         // slice twice since each revert will add a new history object
         setHistory(historyLog.slice(0, -1));
         setHistory(historyLog.slice(0, -1));
+      } else if (e.key === "s") {
+        setTransformMode("scale");
+      } else if (e.key === "r") {
+        setTransformMode("rotate");
+      } else if (e.key === "t") {
+        setTransformMode("translate");
+      } else if (e.key === "Escape") {
+        setTransformMode("none");
+        setSelectedObject(null);
+      } else if (e.key === "k") {
+        // add a keyframe to the selected object
+        if (selectedObject) {
+          addKeyframe(selectedObject.id);
+        }
       }
-    }
+    };
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [selectedObject, arObjects, copyBuffer, setCopyBuffer, setARObjects, historyLog, setHistory]);
+  }, [
+    selectedObject,
+    arObjects,
+    copyBuffer,
+    setCopyBuffer,
+    setARObjects,
+    historyLog,
+    setHistory,
+    addKeyframe,
+    setTransformMode,
+    setSelectedObject,
+  ]);
 
   return (
     <Router>
@@ -101,7 +135,6 @@ const App = () => {
                   {/* AssetControllers remains on the side */}
                   <AssetControllers className="min-w-[20vw] flex-none absolute top-5 right-0" />
                 </div>
-
               </div>
               <SequenceEditor />
             </div>

--- a/arducate/src/components/Canvas.js
+++ b/arducate/src/components/Canvas.js
@@ -121,7 +121,7 @@ const ARCanvas = () => {
     <div className="w-[100vw] border border-gray-500">
       <Canvas camera={{ position: [0, 2, 5], fov: 60 }}>
         <CSS2DRendererSetup />
-        <color attach="background" args={['#343434']} />
+        <color attach="background" args={["#343434"]} />
 
         {/* Lights */}
         <ambientLight intensity={0.5} />

--- a/arducate/src/components/Conversion/VRPublish.js
+++ b/arducate/src/components/Conversion/VRPublish.js
@@ -26,7 +26,7 @@ export const convertSceneToVR = (vrObjects) => {
         </a-entity>
 
         <!-- Camera with movement and look controls -->
-      <a-entity camera look-controls wasd-controls position="0 2 5" look-at="0 0 0"></a-entity>
+      <a-entity camera look-controls wasd-controls position="0 1.6 5" look-at="0 0 0"></a-entity>
       </a-scene>
     </body>
     </html>`;

--- a/arducate/src/components/Conversion/utils.js
+++ b/arducate/src/components/Conversion/utils.js
@@ -38,17 +38,27 @@ const rgbArrayToString = (rgb) => {
  * @returns {string} Concatenated animation string for A-Frame
  */
 export const generateAnimations = (keyframes) => {
-  if (!keyframes || keyframes.length < 2) return ""; // At least 2 keyframes needed for animation
-  return keyframes
+  if (!keyframes || keyframes.length < 2)
+    return { animations: "", labelAnimations: "" }; // At least 2 keyframes needed
+
+  let animations = [];
+  let labelAnimations = [];
+
+  keyframes
     .sort((a, b) => a.time - b.time)
-    .map((kf, index, array) => {
-      if (index === array.length - 1) return "";
+    .forEach((kf, index, array) => {
+      if (index === array.length - 1) return;
 
       const nextKf = array[index + 1];
       const duration = (nextKf.time - kf.time) * 1000;
       const delay = kf.time * 1000;
 
-      const animations = [
+      const rotation = kf.rotation.map((r) => (Math.abs(r) < 0.0001 ? 0 : r));
+      const nextRotation = nextKf.rotation.map((r) =>
+        Math.abs(r) < 0.01 ? 0 : r
+      );
+
+      const animProps = [
         {
           prop: "position",
           from: kf.position?.join(" ") || "0 0 0",
@@ -56,8 +66,8 @@ export const generateAnimations = (keyframes) => {
         },
         {
           prop: "rotation",
-          from: kf.rotation?.join(" ") || "0 0 0",
-          to: nextKf.rotation?.join(" ") || "0 0 0",
+          from: rotation.join(" ") || "0 0 0",
+          to: nextRotation.join(" ") || "0 0 0",
         },
         {
           prop: "scale",
@@ -71,16 +81,23 @@ export const generateAnimations = (keyframes) => {
         },
       ];
 
-      return animations
-        .filter(({ from, to }) => from !== to) // Remove unnecessary animations
-        .map(({ prop, from, to }) => {
+      animProps.forEach(({ prop, from, to }) => {
+        if (from !== to) {
           const property =
             prop === "color" ? "material.color; type: color" : prop;
-          return `animation__${index}_${prop}="property: ${property}; from: ${from}; to: ${to}; dur: ${duration}; delay: ${delay}"`;
-        })
-        .join(" ");
-    })
-    .join(" ");
+          const animString = `animation__${index}_${prop}="property: ${property}; from: ${from}; to: ${to}; dur: ${duration}; delay: ${delay}"`;
+          if (prop === "position") {
+            labelAnimations.push(animString);
+          } 
+          animations.push(animString);
+        }
+      });
+    });
+
+  return {
+    animations: animations.join(" "),
+    labelAnimations: labelAnimations.join(" "),
+  };
 };
 
 /**
@@ -88,7 +105,7 @@ export const generateAnimations = (keyframes) => {
  * @param {Object} object - AR object containing position and label information
  * @returns {string} A-Frame text entity markup
  */
-export const renderTextLabel = (object, yOffset = -1) => {
+export const renderTextLabel = (object, yOffset = -1, animations) => {
   const [_, sy, __] = object.scale;
   const offset = 0.3;
   const localY = yOffset * (sy / 2 + offset);
@@ -101,7 +118,6 @@ export const renderTextLabel = (object, yOffset = -1) => {
       scale="0.5 0.5 0.5"
       align="center"
       color="#000000"
-      look-at="[camera]"
       font="aileronsemibold">
     </a-text>
   `;
@@ -119,9 +135,7 @@ export const getInitialProperties = (object) => {
       position: object.keyframes[0].position || [0, 0, 0],
       rotation: object.keyframes[0].rotation || [0, 0, 0],
       scale: object.keyframes[0].scale || [1, 1, 1],
-      color:
-        rgbArrayToString(object.keyframes[0]?.color) ||
-        object.color,
+      color: rgbArrayToString(object.keyframes[0]?.color) || object.color,
     };
   }
   return {
@@ -139,9 +153,8 @@ export const getInitialProperties = (object) => {
  */
 export const renderObject = (object) => {
   const initialProps = getInitialProperties(object);
-  const animations = generateAnimations(object.keyframes);
-
-  const position = initialProps.position.join(" ");
+  const { animations, labelAnimations } = generateAnimations(object.keyframes);
+  const position = object.position.join(" ");
   const scale = object.scale.join(" ");
   const rotation = object.rotation.join(" ");
 
@@ -181,18 +194,20 @@ export const renderObject = (object) => {
     default:
       const label = renderTextLabel({
         ...object,
-        scale: initialProps.scale,
-        position: initialProps.position,
       });
 
       return `
-          <a-entity position="${position}" rotation="${rotation}" ${animations}>
+          <a-entity position="${initialProps.position}">
             <${object.entity}
               material="color: ${initialProps.color}"
+              rotation="${initialProps.rotation}" 
               scale="${scale}"
-              ${animations}>
+              ${animations}
+              >
             </${object.entity}>
-            ${label}
+            <a-entity look-at="[camera]" ${labelAnimations}>
+             ${label}
+            </a-entity>
           </a-entity>
         `;
   }

--- a/arducate/src/components/Toolbar.js
+++ b/arducate/src/components/Toolbar.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useAtom } from "jotai";
-import { arObjectsAtom, transformModeAtom } from "../atoms";
+import { arObjectsAtom, transformModeAtom, currentTimeAtom } from "../atoms";
 import { convertSceneToAR } from "./Conversion/ARPublish";
 import { convertSceneToVR } from "./Conversion/VRPublish";
 import { Button } from "../@/components/ui/button";
@@ -17,8 +17,10 @@ const Toolbar = () => {
   const [showPopup, setShowPopup] = useState(false); // State to control popup visibility
   const [generatedUrl, setGeneratedUrl] = useState(null); // Check sessionStorage for the URL
   const [popupMessage, setPopupMessage] = useState(''); // State to hold the popup message
+  const [,setCurrentTime] = useAtom(currentTimeAtom);
 
-  const handlePreview = () => {
+  const handlePreview = async () => {
+    await setCurrentTime(0);
     const htmlContent = convertSceneToVR(arObjects);
     const blob = new Blob([htmlContent], { type: "text/html" });
     const url = URL.createObjectURL(blob);

--- a/arducate/src/hooks/objectHandlers.js
+++ b/arducate/src/hooks/objectHandlers.js
@@ -47,17 +47,17 @@ export const useObjectHandlers = () => {
   };
 
   const handleRotationChange = (axis, value) => {
-    if (selectedObject) {
-      const newRotation = [...selectedObject.rotation];
-      newRotation[axis] = parseFloat(value);
-      setARObjects({
-        type: "UPDATE_OBJECT",
-        payload: {
-          ...selectedObject,
-          rotation: newRotation,
-        },
-      });
-    }
+    if (!selectedObject) return;
+    console.log("selectedObject", selectedObject.rotation);
+    const newRotation = [...selectedObject.rotation];
+    newRotation[axis] = parseFloat(value);
+    setARObjects({
+      type: "UPDATE_OBJECT",
+      payload: {
+        ...selectedObject,
+        rotation: newRotation,
+      },
+    });
   };
 
   const handleVisibilityChange = (checked) => {
@@ -115,7 +115,6 @@ export const useObjectHandlers = () => {
         name: e.target.value,
       },
     });
-    
   };
   return {
     handleColorChange,

--- a/arducate/src/hooks/useKeyframe.js
+++ b/arducate/src/hooks/useKeyframe.js
@@ -46,7 +46,7 @@ const useKeyframe = () => {
       const newId = existingKeyframes.length > 0
         ? Math.max(...existingKeyframes.map(kf => kf.id)) + 1
         : 1;
-
+      console.log("rotation", targetObject.rotation);
       let newKeyframe = {
           id: newId,
           time: currentTime,
@@ -56,7 +56,7 @@ const useKeyframe = () => {
           color: hexToRGB(targetObject.color || "#ffa500"),
         };
 
-
+      console.log("Adding keyframe:", newKeyframe);
       setArObjects({
         type: "UPDATE_OBJECT",
         payload: {


### PR DESCRIPTION
## Pull Request - Add shortcuts

k - add keyframe
r - switch to rotation
s - scale
t - translate
esc 

### Description
Provide a detailed description of the changes made in this pull request. Explain why these changes are being proposed.

### Related Issues
Link the issues that this pull request addresses, if applicable.
- Issue: #[issue number]

### How Has This Been Tested?
Describe the tests that you ran to verify your changes. Provide instructions so that others can reproduce. 

- [ ] Test A
- [ ] Test B

### Screenshots (if applicable)
Add screenshots to demonstrate the changes that were made.

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Unit Tests
**Transform Controls:**
- [ ] Whatever is selected in the canvas is selected in left, right sidebars 
- [ ] Whatever is selected in left sidebar is selected in middle, right sidebars
**Change the color, size, position, rotation of one shape**
- [ ] Ensure its persistent after clicking and modifying another shape
- [ ] Ensure its persistent in the Preview Environment
- [ ] Try the buttons & sliders – Make sure it performs as expected

**Preview Environment:**
- [ ] Can move around in the environment as expected (see all sides and all shapes)
- [ ] All the graphics & functionality that appears in editor is in preview (i.e. animation, shapes, color, scale, position…)

**Publish Environment:**
- [ ] Quick scan that graphics & functionality appears same as in preview

**Animation:** 
- [ ] For 2 assets: Can add two assets and apply an animation to both that executes at the same time 
- [ ] For 1 asset: Can move keyframe around for 1 asset animation, 2 keyframes can be added at a time & works

### Additional Context
Add any other context or screenshots about the pull request here
